### PR TITLE
nagios-check 0.2.1 fixes bug in perfdata ordering

### DIFF
--- a/nagios-plugin-vaultaire-throughput.cabal
+++ b/nagios-plugin-vaultaire-throughput.cabal
@@ -31,7 +31,7 @@ executable nagios-plugin-vaultaire-throughput
                        chevalier-common >= 0.6.0,
                        marquise,
                        mtl,
-                       nagios-check,
+                       nagios-check >= 0.2.1,
                        network-uri,
                        optparse-applicative,
                        pipes,


### PR DESCRIPTION
Wait three minutes before merging, need to finish uploading 0.2.1 to hackage.
